### PR TITLE
Switch to double quotes inside the exec

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var exec = require('child_process').exec;
 module.exports = function sysPrefix() {
   return new Promise(function(resolve, reject) {
-    exec('python -c \'import sys; print(sys.prefix)\'',
+    exec('python -c "import sys; print(sys.prefix)"',
       function(err, stdout) {
         if (err !== null) {
           reject(err);


### PR DESCRIPTION
This allows the exec call to work properly with Windows.
